### PR TITLE
[11.0][IMP]sale_manual_delivery

### DIFF
--- a/sale_manual_delivery/__manifest__.py
+++ b/sale_manual_delivery/__manifest__.py
@@ -11,7 +11,7 @@
     "depends": [
         "delivery",
         "sale",
-        "sales_team"
+        "sales_team",
     ],
     "data": [
         "views/crm_team_view.xml",

--- a/sale_manual_delivery/models/procurement.py
+++ b/sale_manual_delivery/models/procurement.py
@@ -6,7 +6,7 @@ from odoo import models, fields
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 
-    scheduled_date = fields.Date()
+    date_planned = fields.Date()
 
     def _get_stock_move_values(
         self,

--- a/sale_manual_delivery/models/sale_order.py
+++ b/sale_manual_delivery/models/sale_order.py
@@ -18,16 +18,18 @@ class SaleOrder(models.Model):
 
     @api.onchange("team_id")
     def _onchange_team_id(self):
-        self.manual_delivery = self.team_id.manual_delivery if self.team_id \
-            else False
+        for so in self:
+            if so.team_id:
+                so.manual_delivery = so.team_id.manual_delivery
+            else:
+                so.manual_delivery = False
 
     @api.multi
     def action_manual_delivery_wizard(self):
         self.ensure_one()
         wizard = self.env["manual.delivery"].create(
-            {"order_id": self.id, "carrier_id": self.carrier_id.id}
+            {"carrier_id": self.carrier_id.id}
         )
-        wizard.onchange_order_id()
         action = self.env.ref(
             "sale_manual_delivery.action_wizard_manual_delivery"
         ).read()[0]

--- a/sale_manual_delivery/models/sale_order_line.py
+++ b/sale_manual_delivery/models/sale_order_line.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Denis Leemann, Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields, models, api
+from odoo.tools import float_compare
 
 
 class SaleOrderLine(models.Model):
@@ -14,6 +15,12 @@ class SaleOrderLine(models.Model):
         readonly=True,
     )
 
+    pending_qty_to_deliver = fields.Boolean(
+        compute='_compute_get_existing_qty',
+        store=True,
+        readonly=True,
+        string='There is Pending qty to add to a delivery')
+
     @api.multi
     def _action_launch_procurement_rule(self):
         for line in self:
@@ -23,12 +30,15 @@ class SaleOrderLine(models.Model):
             else:
                 return super()._action_launch_procurement_rule()
 
+    @api.depends('move_ids', 'move_ids.state', 'move_ids.location_id',
+                 'move_ids.location_dest_id')
     @api.multi
     def _compute_get_existing_qty(self):
         """Computes the remaining quantity on sale order lines, based on related
         done stock moves.
         """
         for line in self:
+            rounding = line.company_id.currency_id.rounding
             qty = 0.0
             for move in line.move_ids.filtered(
                 lambda r: r.state not in ("draft", "cancel") and not r.scrapped
@@ -43,3 +53,9 @@ class SaleOrderLine(models.Model):
                         move.product_uom_qty, line.product_uom
                     )
             line.existing_qty = qty
+            if float_compare(
+                    line.product_uom_qty,
+                    line.existing_qty, precision_rounding=rounding):
+                line.pending_qty_to_deliver = True
+            else:
+                line.pending_qty_to_deliver = False

--- a/sale_manual_delivery/tests/test_manual_delivery.py
+++ b/sale_manual_delivery/tests/test_manual_delivery.py
@@ -1,8 +1,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import fields
 from odoo.addons.sale.tests.test_sale_common import TestSale
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DF
 
 
 class TestSaleStock(TestSale):
@@ -51,16 +51,22 @@ class TestSaleStock(TestSale):
         )
 
         # create a manual delivery for all ordered quantity
-        wizard = self.env["manual.delivery"].create(
-            {
-                "order_id": self.so.id,
-                "carrier_id": self.so.carrier_id.id,
-                "date_planned": datetime.now(),
-            }
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line.ids,
+                }
+            )
+            .create({"date_planned": datetime.now()})
         )
-        wizard.onchange_order_id()
-        for line in wizard.line_ids:
-            line.to_ship_qty = line.ordered_qty
+        wizard.fill_lines(self.so.order_line)
+        wiz_act = self.env.ref(
+            "sale_manual_delivery.action_wizard_manual_delivery"
+        ).read()[0]
+        wiz_act["res_id"] = wizard.id
+        wizard = self.env[wiz_act["res_model"]].browse(wiz_act["res_id"])
         wizard.record_picking()
         # check picking is created
         self.assertTrue(
@@ -70,20 +76,27 @@ class TestSaleStock(TestSale):
         )
 
         # create a manual delivery, nothing left to ship
-        wizard = self.env["manual.delivery"].create(
-            {
-                "order_id": self.so.id,
-                "carrier_id": self.so.carrier_id.id,
-                "date_planned": datetime.now(),
-            }
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line.ids,
+                }
+            )
+            .create({"date_planned": datetime.now()})
         )
-        wizard.onchange_order_id()
+        wizard.fill_lines(self.so.order_line)
+        wiz_act = self.env.ref(
+            "sale_manual_delivery.action_wizard_manual_delivery"
+        ).read()[0]
+        wiz_act["res_id"] = wizard.id
+        wizard = self.env[wiz_act["res_model"]].browse(wiz_act["res_id"])
         self.assertFalse(
             wizard.line_ids,
             "Sale Manual Delivery: After picking \
             creation for all products, no lines should be left in the wizard",
         )
-
         wizard.record_picking()
         self.assertEqual(
             len(self.so.picking_ids),
@@ -203,14 +216,22 @@ class TestSaleStock(TestSale):
         )
 
         # create a manual delivery for part of ordered quantity
-        wizard = self.env["manual.delivery"].create(
-            {
-                "order_id": self.so.id,
-                "carrier_id": self.so.carrier_id.id,
-                "date_planned": datetime.now(),
-            }
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line.ids,
+                }
+            )
+            .create({'date_planned': datetime.now()})
         )
-        wizard.onchange_order_id()
+        wizard.fill_lines(self.so.order_line)
+        wiz_act = self.env.ref(
+            "sale_manual_delivery.action_wizard_manual_delivery"
+        ).read()[0]
+        wiz_act["res_id"] = wizard.id
+        wizard = self.env[wiz_act["res_model"]].browse(wiz_act["res_id"])
         for line in wizard.line_ids:
             line.to_ship_qty = 2.0
         wizard.record_picking()
@@ -238,14 +259,23 @@ class TestSaleStock(TestSale):
         )
 
         # create a manual delivery, 3.0 left to ship
-        wizard = self.env["manual.delivery"].create(
-            {
-                "order_id": self.so.id,
-                "carrier_id": self.so.carrier_id.id,
-                "date_planned": datetime.now(),
-            }
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line.ids,
+                }
+            )
+            .create({"carrier_id": self.so.carrier_id.id,
+                     "date_planned": datetime.now()})
         )
-        wizard.onchange_order_id()
+        wizard.fill_lines(self.so.order_line)
+        wiz_act = self.env.ref(
+            "sale_manual_delivery.action_wizard_manual_delivery"
+        ).read()[0]
+        wiz_act["res_id"] = wizard.id
+        wizard = self.env[wiz_act["res_model"]].browse(wiz_act["res_id"])
         for line in wizard.line_ids:
             line.to_ship_qty = 3.0
         wizard.record_picking()
@@ -273,6 +303,136 @@ class TestSaleStock(TestSale):
             "Sale Stock: delivered quantity should \
             be 5.0 instead of %s after complete delivery"
             % del_qty,
+        )
+
+    def test_03_sale_selected_lines(self):
+        """
+        Test SO's various manual delivery
+        """
+        self.partner = self.env.ref("base.res_partner_1")
+        self.product = self.env.ref("product.product_delivery_01")
+        self.product2 = self.env.ref("product.product_delivery_02")
+        self.product3 = self.env.ref("product.product_order_01")
+        so_vals = {
+            "partner_id": self.partner.id,
+            "partner_invoice_id": self.partner.id,
+            "partner_shipping_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": self.product.name,
+                        "product_id": self.product.id,
+                        "product_uom_qty": 1.0,
+                        "product_uom": self.product.uom_id.id,
+                        "price_unit": self.product.list_price,
+                    },
+                )
+            ],
+            "pricelist_id": self.env.ref("product.list0").id,
+            "manual_delivery": True,
+        }
+        self.so1 = self.env["sale.order"].create(so_vals)
+        so_vals = {
+            "partner_id": self.partner.id,
+            "partner_invoice_id": self.partner.id,
+            "partner_shipping_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": self.product2.name,
+                        "product_id": self.product2.id,
+                        "product_uom_qty": 2.0,
+                        "product_uom": self.product2.uom_id.id,
+                        "price_unit": self.product2.list_price,
+                    },
+                )
+            ],
+            "pricelist_id": self.env.ref("product.list0").id,
+            "manual_delivery": True,
+        }
+        self.so2 = self.env["sale.order"].create(so_vals)
+
+        so_vals = {
+            "partner_id": self.partner.id,
+            "partner_invoice_id": self.partner.id,
+            "partner_shipping_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": self.product3.name,
+                        "product_id": self.product.id,
+                        "product_uom_qty": 3.0,
+                        "product_uom": self.product3.uom_id.id,
+                        "price_unit": self.product3.list_price,
+                    },
+                )
+            ],
+            "pricelist_id": self.env.ref("product.list0").id,
+            "manual_delivery": True,
+        }
+        self.so3 = self.env["sale.order"].create(so_vals)
+
+        # confirm our standard so, check the picking
+        self.so1.action_confirm()
+        self.so2.action_confirm()
+        self.so3.action_confirm()
+        some_lines = self.so1.order_line + self.so3.order_line
+        all_lines = (
+            self.so1.order_line + self.so2.order_line + self.so3.order_line
+        )
+        # create a manual delivery for part of ordered quantity
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": some_lines.ids,
+                }
+            )
+            .create({'date_planned': datetime.now()})
+        )
+        wizard.fill_lines(some_lines)
+        wiz_act = self.env.ref(
+            "sale_manual_delivery.action_wizard_manual_delivery"
+        ).read()[0]
+        wiz_act["res_id"] = wizard.id
+        wizard = self.env[wiz_act["res_model"]].browse(wiz_act["res_id"])
+        self.assertEqual(sum(wizard.line_ids.mapped("to_ship_qty")), 4.0)
+        wizard.record_picking()
+        # check picking is created
+        self.assertTrue(
+            self.so3.picking_ids,
+            'Sale Manual Delivery: picking \
+            should be created after "manual delivery" wizard call',
+        )
+        self.assertEqual(
+            len(self.so3.picking_ids.move_lines), 1,
+            'Different sales orders should still create different pickings'
+        )
+        self.assertFalse(
+            self.so2.picking_ids,
+            'Sale Manual Delivery: picking \
+            should not be created after "manual delivery" wizard call',
+        )
+        # test action undelivered
+        # self.env['sale.order.line'].search([])._compute_existing_qty()
+        undelivered = (
+            self.env["sale.order.line"]
+            .search(
+                [("pending_qty_to_deliver", "=", True), ("state", "=", "sale")]
+            )
+            .filtered(lambda s: s.id in all_lines.ids)
+        )
+        self.assertEqual(
+            undelivered,
+            self.so2.order_line,
+            "Bad pending qty to deliver filter",
         )
 
     def test_03_sale_multi_delivery(self):
@@ -308,13 +468,22 @@ class TestSaleStock(TestSale):
         self.assertFalse(self.so.picking_ids, 'Sale Manual Delivery: no \
             picking should be created for "manual delivery" orders')
         # create a manual delivery for part of ordered quantity
-        date_now = datetime.now()
-        wizard = self.env['manual.delivery'].create({
-            'order_id': self.so.id,
-            'carrier_id': self.so.carrier_id.id,
-            'date_planned': date_now,
-        })
-        wizard.onchange_order_id()
+        date_now = datetime.now().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line[0].ids,
+                }
+            )
+            .create(
+                {"carrier_id": self.so.carrier_id.id, "date_planned": date_now}
+            )
+        )
+        wizard.fill_lines(self.so.order_line)
         for line in wizard.line_ids:
             line.to_ship_qty = 2.0
         wizard.record_picking()
@@ -323,51 +492,144 @@ class TestSaleStock(TestSale):
             len(self.so.picking_ids),
             1,
             'Sale Manual Delivery: picking should be created after "manual'
-            ' delivery" wizard call'
+            ' delivery" wizard call',
         )
         first_picking = self.so.picking_ids
         self.assertEqual(
-            first_picking.scheduled_date, fields.Datetime.to_string(date_now)
+            datetime.strptime(first_picking.scheduled_date, DF).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            ),
+            date_now,
         )
         # create a second manual delivery for next week
         date_next_week = date_now + relativedelta(weeks=1)
-        wizard = self.env['manual.delivery'].create({
-            'order_id': self.so.id,
-            'carrier_id': self.so.carrier_id.id,
-            'date_planned': date_next_week,
-        })
-        wizard.onchange_order_id()
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line[1].ids,
+                }
+            )
+            .create(
+                {
+                    "carrier_id": self.so.carrier_id.id,
+                    "date_planned": date_next_week,
+                }
+            )
+        )
+        wizard.fill_lines(self.so.order_line)
         for line in wizard.line_ids:
             line.to_ship_qty = 3.0
         wizard.record_picking()
         self.assertEqual(
             len(self.so.picking_ids),
             2,
-            'Sale Manual Delivery: second picking should be created after'
-            ' "manual delivery" wizard call with different date'
+            "Sale Manual Delivery: second picking should be created after"
+            ' "manual delivery" wizard call with different date',
         )
         second_picking = self.so.picking_ids - first_picking
         self.assertEqual(
-            second_picking.scheduled_date,
-            fields.Datetime.to_string(date_next_week)
+            datetime.strptime(second_picking.scheduled_date, DF).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            ),
+            date_next_week,
         )
         # create a third manual delivery for today (should be mixed with first)
         new_date_now = datetime.now()
-        wizard = self.env['manual.delivery'].create({
-            'order_id': self.so.id,
-            'carrier_id': self.so.carrier_id.id,
-            'date_planned': new_date_now,
-        })
-        wizard.onchange_order_id()
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so.order_line[0].ids,
+                }
+            )
+            .create(
+                {
+                    "carrier_id": self.so.carrier_id.id,
+                    "date_planned": new_date_now,
+                }
+            )
+        )
+        wizard.fill_lines(self.so.order_line)
         for line in wizard.line_ids:
             line.to_ship_qty = 5.0
         wizard.record_picking()
         self.assertEqual(
             len(self.so.picking_ids),
             2,
-            'Sale Manual Delivery: new moves should be merged in first picking'
-            ' after "manual delivery" wizard call with same date'
-
+            "Sale Manual Delivery: new moves should be merged in first picking"
+            ' after "manual delivery" wizard call with same date',
         )
-        for move in first_picking.move_lines:
-            self.assertEqual(move.product_uom_qty, 7)
+        self.assertEqual(
+            sum(first_picking.mapped("move_lines.product_uom_qty")), 7
+        )
+
+    def test_04_sale_single_picking(self):
+        """
+        Test SO's various manual delivery
+        """
+        self.partner = self.env.ref("base.res_partner_1")
+        self.product = self.env.ref("product.product_delivery_01")
+        self.product2 = self.env.ref("product.product_delivery_02")
+        so_vals = {
+            "partner_id": self.partner.id,
+            "partner_invoice_id": self.partner.id,
+            "partner_shipping_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": self.product.name,
+                        "product_id": self.product.id,
+                        "product_uom_qty": 1.0,
+                        "product_uom": self.product.uom_id.id,
+                        "price_unit": self.product.list_price,
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": self.product2.name,
+                        "product_id": self.product2.id,
+                        "product_uom_qty": 2.0,
+                        "product_uom": self.product2.uom_id.id,
+                        "price_unit": self.product2.list_price,
+                    },
+                ),
+            ],
+            "pricelist_id": self.env.ref("product.list0").id,
+            "manual_delivery": True,
+        }
+        self.so1 = self.env["sale.order"].create(so_vals)
+        # confirm our standard so, check the picking
+        self.so1.action_confirm()
+        # create a manual delivery for part of ordered quantity
+        wizard = (
+            self.env["manual.delivery"]
+            .with_context(
+                {
+                    "active_model": "sale.order.line",
+                    "active_ids": self.so1.order_line.ids,
+                }
+            )
+            .create({'date_planned': datetime.now()})
+        )
+        wizard.fill_lines(self.so1.order_line)
+        wiz_act = self.env.ref(
+            "sale_manual_delivery.action_wizard_manual_delivery"
+        ).read()[0]
+        wiz_act["res_id"] = wizard.id
+        wizard = self.env[wiz_act["res_model"]].browse(wiz_act["res_id"])
+        wizard.record_picking()
+        self.assertEqual(
+            len(self.so1.picking_ids),
+            1.0,
+            "Sale Manual \
+            Delivery: picking number should be 1.0 instead of %s as created\
+            at once"
+            % len(self.so1.picking_ids),
+        )

--- a/sale_manual_delivery/views/sale_order_view.xml
+++ b/sale_manual_delivery/views/sale_order_view.xml
@@ -5,9 +5,6 @@
         <field name='model'>sale.order</field>
         <field name='inherit_id' ref="sale.view_order_form"/>
         <field name='arch' type="xml">
-          <!--   <xpath expr="//field[@name='payment_term_id']" position="after">
-                <field name='manual_delivery'/>
-            </xpath> -->
             <xpath expr="//button[@name='action_view_invoice']" position="after">
                      <button name="toggle_manual" type="object"
                             class="oe_stat_button" icon="fa-calendar">
@@ -24,9 +21,95 @@
            <xpath expr="header" position="inside">
                 <button name="action_manual_delivery_wizard" string="Create Delivery"
                         type="object" class="btn btn-primary"
+                        context="{'active_model': 'sale.order',
+                        'active_id': id,
+                        'active_ids': [id]}"
                         attrs="{'invisible': ['|',('manual_delivery', '=', False), ('state', '!=', 'sale')]}"
                         />
             </xpath>
         </field>
     </record>
+
+    <record id="view_order_line_tree" model="ir.ui.view">
+        <field name="name">sale.order.line.tree</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="sale.view_order_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="price_subtotal" position="after">
+                <field name="existing_qty" />
+                <field name="pending_qty_to_deliver" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_order_line_form2" model="ir.ui.view">
+        <field name="name">sale.order.line.form2</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <form string="Sales Order Lines" create="0" edit="0" delete="0">
+                <sheet>
+                <label for="order_id" class="oe_edit_only"/>
+                <h1><field name="order_id"/></h1>
+                <label for="order_partner_id" class="oe_edit_only"/>
+                <h2><field name="order_partner_id"/></h2>
+                <group>
+                    <group>
+                        <field name="state" invisible="1"/>
+                        <field name="product_id"/>
+                        <label for="product_uom_qty"/>
+                        <div>
+                            <field name="product_uom_qty" readonly="1" class="oe_inline"/>
+                            <field name="product_uom" groups="product.group_uom" class="oe_inline"/>
+                        </div>
+                    </group>
+                    <group>
+                        <field name="price_unit"/>
+                        <field name="discount" groups="sale.group_discount_per_so_line"/>
+                        <field name="price_subtotal"/>
+                        <field name="qty_invoiced"/>
+                        <field name="qty_to_invoice"/>
+                        <field name="company_id" groups="base.group_multi_company" readonly="1"/>
+                    </group>
+                </group>
+                <label for="name"/>
+                <field name="name"/>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+
+    <record id="view_sales_order_undelivered_line_filter" model="ir.ui.view">
+        <field name="name">sale.order.undelivered.line</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <search string="Search Undelivered Lines">
+                <field name="order_id"/>
+                <separator/>
+                <filter string="Pending to deliver" name="undelivered" domain="[('pending_qty_to_deliver','=', True), ('state', '=', 'sale')]" help="Sales Order Lines that are confirmed, done or in exception state and no delivery is created to satisfy them"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_order_line_delivery_tree" model="ir.actions.act_window">
+            <field name="name">Sale Lines to Deliver</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">sale.order.line</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="search_view_id" ref="view_sales_order_undelivered_line_filter"/>
+            <field name="context">{"search_default_undelivered":1}</field>
+            <field name="filter" eval="True"/>
+            <field name="help" type="html">
+              <p>
+                Here is a list of each sales order line to be invoiced.
+              </p>
+            </field>
+    </record>
+
+    <menuitem id="menu_delivery_sales_order_lines"
+          parent="stock.menu_stock_warehouse_mgmt"
+          action="action_order_line_delivery_tree" sequence="99"
+          groups="stock.group_stock_user"/>
+
 </odoo>

--- a/sale_manual_delivery/wizard/line.py
+++ b/sale_manual_delivery/wizard/line.py
@@ -6,38 +6,36 @@ from odoo import models, fields, api
 
 class ManualDeliveryLine(models.TransientModel):
     _name = "manual.delivery.line"
+    _description = "Manual Delivery Line"
 
     manual_delivery_id = fields.Many2one(
         "manual.delivery", string="Wizard manual procurement"
     )
     order_line_id = fields.Many2one(
-        "sale.order.line", string="Sale Order Line", readonly=True
+        "sale.order.line", string="Sale Order Line",
     )
     product_id = fields.Many2one(
         "product.product",
         string="Product",
         related="order_line_id.product_id",
-        readonly=True,
     )
     line_description = fields.Text(
-        string="Description", related="order_line_id.name", readonly=True
+        string="Description", related="order_line_id.name",
     )
     ordered_qty = fields.Float(
         "Ordered quantity",
+        related='order_line_id.product_uom_qty',
         help="Quantity ordered in the related Sale Order",
-        readonly=True,
     )
     existing_qty = fields.Float(
         "Existing quantity",
         help="Quantity already planned or shipped (stock movements \
-            already created)",
-        readonly=True,
+            already created)"
     )
     remaining_qty = fields.Float(
         "Remaining quantity",
         compute="_compute_remaining_qty",
         help="Remaining quantity available to deliver",
-        readonly=True,
     )
     to_ship_qty = fields.Float("Quantity to Ship")
 

--- a/sale_manual_delivery/wizard/manual_proc.py
+++ b/sale_manual_delivery/wizard/manual_proc.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, fields, api
-from odoo.tools import float_compare
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, float_compare
 from odoo.exceptions import UserError
 from odoo.tools.translate import _
 
@@ -11,38 +11,55 @@ class ManualDelivery(models.TransientModel):
     """Creates procurements manually"""
 
     _name = "manual.delivery"
+    _description = "Manual Delivery"
     _order = "create_date desc"
 
-    def _set_order_id(self):
-        return self.env["sale.order"].browse(self._context["active_ids"])
+    @api.model
+    def default_get(self, fields):
+        if 'line_ids' not in fields:
+            return {}
+        res = super(ManualDelivery, self).default_get(
+            fields)
 
-    @api.onchange("order_id")
-    def onchange_order_id(self):
+        active_model = self.env.context['active_model']
+        if active_model == 'sale.order.line':
+            sale_ids = self.env.context['active_ids'] or []
+            sale_lines = self.env['sale.order.line'].browse(sale_ids).filtered(
+                lambda s: s.pending_qty_to_deliver)
+        elif active_model == 'sale.order':
+            sale_ids = self.env.context['active_ids'] or []
+            sale_lines = self.env['sale.order'].browse(sale_ids).mapped(
+                'order_line').filtered(
+                lambda s: s.pending_qty_to_deliver)
+        if len(sale_lines.mapped('order_id.partner_id')) > 1:
+            raise UserError(_('Please select one partner at a time'))
+        res['line_ids'] = self.fill_lines(sale_lines)
+        res['partner_id'] = sale_lines.mapped('order_id.partner_id').id
+        return res
+
+    @api.multi
+    def fill_lines(self, sale_lines):
         lines = []
-        if self.order_id:
-            for line in self.order_id.order_line:
-                if (
-                    not line.existing_qty == line.product_uom_qty
-                    and line.product_id.type != "service"
-                ):
-                    vals = {
-                        "order_line_id": line.id,
-                        "ordered_qty": line.product_uom_qty,
-                        "existing_qty": line.existing_qty,
-                    }
-                    lines.append((0, 0, vals))
-            self.update({"line_ids": lines})
 
-            self.partner_id = self.order_id.partner_id
+        for line in sale_lines:
+            if (not line.existing_qty == line.product_uom_qty and
+               line.product_id.type != 'service'):
+                vals = {
+                    'product_id': line.product_id.id,
+                    'line_description': line.product_id.name,
+                    'order_line_id': line.id,
+                    'ordered_qty': line.product_uom_qty,
+                    'existing_qty': line.existing_qty,
+                    'to_ship_qty': line.product_uom_qty - line.existing_qty
+                }
+                lines.append((0, 0, vals))
+        return lines
 
     date_planned = fields.Datetime(string="Date Planned")
-    order_id = fields.Many2one(
-        "sale.order", string="Sale Order", default=_set_order_id  # TODO HIDE
-    )
     line_ids = fields.One2many(
-        "manual.delivery.line",
-        "manual_delivery_id",
-        string="Lines to validate"
+        'manual.delivery.line',
+        'manual_delivery_id',
+        string='Lines to validate',
     )
     carrier_id = fields.Many2one("delivery.carrier", string="Delivery Method")
     partner_id = fields.Many2one("res.partner", string="Delivery Address")
@@ -63,61 +80,63 @@ class ManualDelivery(models.TransientModel):
 
     @api.multi
     def record_picking(self):
-        proc_group_obj = self.env["procurement.group"]
+        proc_group_obj = self.env['procurement.group']
+        proc_group_dict = {}
         for wizard in self:
-            carrier_id = wizard.carrier_id if wizard.carrier_id \
-                else wizard.order_id.carrier_id
             date_planned = wizard.date_planned
-            order = wizard.order_id
-            # Use a procurement group according to date planned
-            if not order.procurement_group_id:
-                vals = {
-                    "name": order.name,
-                    "move_type": order.picking_policy,
-                    "sale_id": order.id,
-                    "partner_id": order.partner_shipping_id.id,
-                    "scheduled_date": date_planned,
-                }
-                order.procurement_group_id = proc_group_obj.create(vals)
-                proc_group_to_use = order.procurement_group_id
-            else:
-                proc_group_to_use = self.env['procurement.group'].search(
-                    [
-                        ('sale_id', '=', order.id),
-                        (
-                            'scheduled_date',
-                            '=',
-                            fields.Date.from_string(date_planned)
-                         ),
-                    ], limit=1
-                )
-                if not proc_group_to_use:
-                    proc_group_to_use = order.procurement_group_id.copy({
-                        'scheduled_date': date_planned,
-                    })
-            for line in wizard.line_ids:
-                if line.to_ship_qty > line.ordered_qty - line.existing_qty:
-                    raise UserError(
-                        _(
-                            "You can not deliver more than the "
-                            "remaining quantity. If you need to do "
-                            "so, please edit the sale order first."
-                        )
+            for line in wizard.mapped('line_ids.order_line_id'):
+                order = line.order_id
+                if not order.procurement_group_id:
+                    vals = line._prepare_procurement_values(group_id=False)
+                    if wizard.date_planned:
+                        vals['date_planned'] = date_planned
+                        vals['sale_id'] = order.id
+                    order_proc_group_to_use = \
+                        order.procurement_group_id = proc_group_obj.create(
+                            vals)
+                else:
+                    order_proc_group_to_use = self.env[
+                        'procurement.group'].search(
+                        [
+                            ('sale_id', '=', order.id),
+                            ('date_planned', '=', date_planned),
+                        ], limit=1
                     )
-                if float_compare(line.to_ship_qty, 0, 2):
-                    vals = line.order_line_id._prepare_procurement_values(
-                        group_id=proc_group_to_use
-                    )
+                    if not order_proc_group_to_use:
+                        order_proc_group_to_use = order.procurement_group_id.\
+                            copy({
+                            'date_planned': date_planned,
+                            })
+                proc_group_dict[order.id] = order_proc_group_to_use
+
+            for wiz_line in wizard.line_ids:
+                rounding = wiz_line.order_line_id.company_id.\
+                    currency_id.rounding
+                carrier_id = wizard.carrier_id if wizard.carrier_id else \
+                    wiz_line.order_line_id.order_id.carrier_id
+                if float_compare(wiz_line.to_ship_qty,
+                                 wiz_line.ordered_qty -
+                                 wiz_line.existing_qty,
+                                 precision_rounding=rounding) > 0.0:
+                    raise UserError(_('You can not deliver more than the '
+                                      'remaining quantity. If you need to do '
+                                      'so, please edit the sale order first.'))
+                if float_compare(wiz_line.to_ship_qty, 0, 2):
+                    so_id = wiz_line.order_line_id.order_id
+                    proc_group_to_use = proc_group_dict[so_id.id]
+                    vals = wiz_line.order_line_id.\
+                        _prepare_procurement_values(
+                            group_id=proc_group_to_use)
                     vals["date_planned"] = date_planned
                     vals["carrier_id"] = carrier_id.id
                     vals["partner_dest_id"] = wizard.partner_id.id
-                    so_id = line.order_line_id.order_id
+
                     proc_group_obj.run(
-                        line.order_line_id.product_id,
-                        line.to_ship_qty,
-                        line.order_line_id.product_uom,
+                        wiz_line.order_line_id.product_id,
+                        wiz_line.to_ship_qty,
+                        wiz_line.order_line_id.product_uom,
                         so_id.partner_shipping_id.property_stock_customer,
-                        line.order_line_id.name,
+                        wiz_line.order_line_id.name,
                         so_id.name,
                         vals,
                     )

--- a/sale_manual_delivery/wizard/manual_proc_view.xml
+++ b/sale_manual_delivery/wizard/manual_proc_view.xml
@@ -1,54 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-  <record id='manual_delivery_wizard_form' model='ir.ui.view'>
-    <field name='name'>manual_delivery_wizard_form</field>
-    <field name='model'>manual.delivery</field>
-    <field name='arch' type='xml'>
+    <record id='manual_delivery_wizard_form' model='ir.ui.view'>
+        <field name="name">manual.delivery.wizard.form</field>
+        <field name="model">manual.delivery</field>
+        <field name='arch' type='xml'>
+            <form string="Create Manually Delivery" name="manual_procurment_form">
+                <sheet>
+                    <group name="date">
+                        <field name='date_planned' required="1"/>
+                    </group>
+                    <group name="carrier">
+                        <field name='carrier_id'/>
+                    </group>
+                    <field name='line_ids'>
+                        <tree editable="bottom" create="0">
+                            <field name='manual_delivery_id' invisible="1"/>
+                            <field name='order_line_id' invisible="1"/>
+                            <field name='product_id' readonly="True"/>
+                            <field name='line_description' readonly="True"/>
+                            <field name='ordered_qty' readonly="True"/>
+                            <field name='existing_qty' readonly="True"/>
+                            <field name='to_ship_qty' readonly="False"/>
+                        </tree>
+                    </field>
+                </sheet>
+                <footer>
+                    <button name='record_picking'
+                            string='Create Picking'
+                            class='btn-primary'
+                            type='object'/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
 
-      <form string="Create Manually Delivery" name="manual_procurment_form">
-        <sheet>
-          <group>
-            <field name='date_planned' required="1"/>
-            <field name='order_id' invisible="1"/>
-          </group>
-          <group>
-            <field name='carrier_id'/>
-          </group>
-          <group>
-            <field name='partner_id' required="1"/>
-          </group>
-          <field name='line_ids'>
-            <tree editable="bottom" create="0">
-              <field name='manual_delivery_id' invisible="1"/>
-              <field name='order_line_id' invisible="1"/>
-              <field name='product_id'/>
-              <field name='line_description'/>
-              <field name='ordered_qty'/>
-              <field name='existing_qty'/>
-              <field name='remaining_qty'/>
-              <field name='to_ship_qty'/>
-            </tree>
-          </field>
-        </sheet>
-        <footer>
-          <button name='record_picking'
-                  string='Create Picking'
-                  class='btn-primary'
-                  type='object'/>
-          <button string="Cancel" class="btn-default" special="cancel" />
-        </footer>
-      </form>
+        </field>
+    </record>
 
-    </field>
-  </record>
-
-  <act_window id='action_wizard_manual_delivery'
+    <act_window id='action_wizard_manual_delivery'
               name='Create Manual Delivery'
               src_model='sale.order'
               res_model='manual.delivery'
               view_mode='form'
               key2='client_action_multi'
+              target='new'/>
+
+    <act_window id='action_wizard_manual_delivery_line'
+              name='Create Manual Delivery'
+              src_model='sale.order.line'
+              res_model='manual.delivery'
+              key2='client_action_multi'
+              view_mode='form'
               target='new'/>
 
 </odoo>


### PR DESCRIPTION
Forward port of the changes made on https://github.com/OCA/sale-workflow/pull/935

The main objective of this PR is to allow do manual deliveries from sale order lines directly. This way the people at the warehouse just need to go to `Inventory > Sale Lines to Deliver` and then select the lines they want to deliver.

The base functionality of this module remains the same:
-  Create the manual delivery form the sale order line
-  Split pickings when the schedule date is different
- Split pickings for different sales order (Standard Odoo)

Added also a specific use case when creating the delivery from the line.
